### PR TITLE
Deploy: poll container health status, not a raw curl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,19 +56,23 @@ jobs:
             docker-compose -f docker-compose.prod.yml build
             docker-compose -f docker-compose.prod.yml up -d
 
-            # Wait for services to be healthy. Poll the containers directly
-            # (ports bypass the nginx maintenance gate). This box is memory-tight,
-            # so startup (migrate + collectstatic + gunicorn / Next boot) can be
-            # slow - allow up to 300s.
+            # Wait for services to be healthy using each container's OWN
+            # healthcheck status (docker-compose.prod.yml defines them with the
+            # correct Host, so this avoids ALLOWED_HOSTS 400s that a raw
+            # 127.0.0.1 curl would hit). This box is memory-tight, so startup
+            # (migrate + collectstatic + gunicorn / Next boot) can be slow -
+            # allow up to 300s and print a heartbeat so the log never looks stuck.
             echo "Waiting for services to become healthy..."
             healthy=0
             for i in $(seq 1 100); do
-              if curl -fs http://127.0.0.1:8002/api/health/ >/dev/null 2>&1 \
-                 && curl -fs -o /dev/null http://127.0.0.1:3002/; then
+              be=$(docker inspect -f '{{.State.Health.Status}}' vib-backend 2>/dev/null || echo missing)
+              fe=$(docker inspect -f '{{.State.Health.Status}}' vib-frontend 2>/dev/null || echo missing)
+              if [ "$be" = "healthy" ] && [ "$fe" = "healthy" ]; then
                 healthy=1
                 echo "Services healthy after $((i * 3))s"
                 break
               fi
+              [ $((i % 10)) -eq 0 ] && echo "  still waiting (${i}x3s): backend=$be frontend=$fe"
               sleep 3
             done
 


### PR DESCRIPTION
The 127.0.0.1 health curl sent Host: 127.0.0.1, which Django rejects via ALLOWED_HOSTS (400), so the health wait always timed out and the deploy falsely reported failure. Use each container's own healthcheck status (defined with the correct host) and print a heartbeat so the wait is visible.